### PR TITLE
added filter to look for environment source in aws only

### DIFF
--- a/scripts/deploy_alertlogic.py
+++ b/scripts/deploy_alertlogic.py
@@ -90,7 +90,7 @@ def post_credentials(token, payload, target_cid, insight_dc):
     return RESULT
 
 def get_source_environment(token, target_cid, cred_id, project_name, insight_dc):
-    api_endpoint = "https://api.cloudinsight" + insight_dc + "/sources/v1/" + target_cid + "/sources?source.type=environment"
+    api_endpoint = "https://api.cloudinsight" + insight_dc + "/sources/v1/" + target_cid + "/sources?source.type=environment&source.config.collection_type=aws"
     request = requests.get(api_endpoint, headers={'x-aims-auth-token': token}, verify=False)
     results = json.loads(request.text)
     for source in results["sources"]:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "deploy_alertlogic.py", line 588, in <module>
    ENV = get_source_environment(TOKEN, CID, CRED["credential"]["id"], PROJECT_NAME, ALERT_LOGIC_CI_DC)
  File "deploy_alertlogic.py", line 98, in get_source_environment
    if source["source"]["config"]["aws"]["credential"]["id"] == cred_id:
KeyError: 'aws'
```